### PR TITLE
Add gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/composer.lock export-ignore
+/tests/ export-ignore


### PR DESCRIPTION
Used by composer to ignore tests and other development files in the
distribution of a release.